### PR TITLE
Upgrade https-proxy-agent to drop rewrite of `https.request()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,8 @@
     "pre-commit": "^1.2.2"
   },
   "dependencies": {
-    "https-proxy-agent": "^2.1.1",
+    "https-proxy-agent": "^5.0.0",
     "lodash": "^4.17.4",
-    "xml2js": "^0.4.17",
-    "http-proxy-agent": "^2.1.0"
+    "xml2js": "^0.4.17"
   }
 }


### PR DESCRIPTION
* https-proxy-agent v2.1.1 to v5.0.0
* http-proxy-agent removed (not used in code)

You use a old and strange version of https-proxy-agent who rewrite the
original function 'https.request()' ...

https://github.com/TooTallNate/node-agent-base/blob/4.3.0/patch-core.js#L13

This rewrite are not neccesary and produce bug when we use a Url object.

`Object.assign({}, _options);` will transform a Url into Symbol

https://www.diffchecker.com/NGxe92j3