### PR TITLE
upload: stream to handle larger files

### DIFF
--- a/lib/api-request.js
+++ b/lib/api-request.js
@@ -91,13 +91,19 @@ class Requestor {
 
     if (requestArgs.action == 'upload') {
       try {
-        request.write(fs.readFileSync(requestArgs.source))
+        const stream = fs.createReadStream(requestArgs.source);
+
+        stream.on('end', function () {
+          request.end()
+        });
+
+        stream.pipe(request);
       } catch (err) {
         callback(err, null, null)
       }
+    } else {
+      request.end()
     }
-
-    request.end()
   }
 
   validatePath(path) {

--- a/test/test-netstorage.js
+++ b/test/test-netstorage.js
@@ -87,6 +87,16 @@ describe('### Netstorage test ###', function() {
         done()
       })
     })
+
+    it('should return 200 OK for large files (6mb+)', function (done) {
+      const sixMegsPlusOne = new Array(6 * 1024 * 1024 + 1).fill('a').join('')
+      fs.writeFileSync(`${__dirname}/${temp_file}`, sixMegsPlusOne)
+      ns.upload(`${__dirname}/${temp_file}`, temp_ns_file, (error, response, body) => {
+        if (error) { throw error }
+        expect(response.statusCode).to.equal(200)
+        done()
+      })
+    })
   })
 
   describe(`ns.du("${temp_ns_dir}", callback);`, function() {


### PR DESCRIPTION
Large files get truncated when uploading. In my case a 5.5 meg file gets cut off at about 4 megs.

This is fixed by switching to streaming the upload.